### PR TITLE
Make PostreSQL happy when computing max id

### DIFF
--- a/factory_peewee/__init__.py
+++ b/factory_peewee/__init__.py
@@ -27,8 +27,7 @@ class PeeweeModelFactory(base.Factory):
         model = cls._meta.model
         pk = getattr(model, model._meta.primary_key.name)
         max_pk = model.select(
-            model, peewee.fn.Max(pk).alias('maxpk')
-        ).limit(1).execute()
+                        peewee.fn.Max(pk).alias('maxpk')).limit(1).execute()
         max_pk = [mp.maxpk for mp in max_pk][0]
         if isinstance(max_pk, int):
             return max_pk + 1 if max_pk else 1


### PR DESCRIPTION
Asking for models fields fails with:

```
ERROR:  column "t1.id" must appear in the GROUP BY clause or be used in an aggregate function
LINE 1: SELECT "t1"."id", "t1"."version", "t1"."created_at", "t1"."c...
```
